### PR TITLE
Add API proxy to solve cookies problems

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
-NEXT_PUBLIC_API_URL=https://web.tella-app.org
+NEXT_REDIRECT_API_URL=https://web.tella-app.org
+NEXT_PUBLIC_API_URL=/api

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,11 @@
 module.exports = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: process.env.NEXT_PUBLIC_API_URL + "/:path*",
+        destination: process.env.NEXT_REDIRECT_API_URL + "/:path*",
+      },
+    ];
+  },
 };


### PR DESCRIPTION
The cookie authentication problem is due to the fact that the backend and frontend are in different domains. Nextjs has a special configuration for that: **rewrites**. https://nextjs.org/docs/api-reference/next.config.js/rewrites

In this pull request, in addition to the nextjs configuration changes, I add an environment variable to control the path of the frontend url that will be used as a proxy for the backend. 