### PR TITLE
Feat/use - Use redux toolkit cache invalidation

### DIFF
--- a/packages/state/store.ts
+++ b/packages/state/store.ts
@@ -18,6 +18,13 @@ const store = configureStore({
     user: userSlice.reducer,
     reports: reportsSlice.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(
+      authApi.middleware,
+      userApi.middleware,
+      reportsApi.middleware,
+      filesApi.middleware
+    ),
 });
 
 setupListeners(store.dispatch);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,14 +5,17 @@ import type { AppProps } from "next/app";
 import { ToastWrapper } from "../components/ToastWrapper";
 import { Provider } from "react-redux";
 import store from "packages/state/store";
+import { useRouter } from "next/router";
 
 function TellaWeb({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   return (
     <Provider store={store}>
       <ToastWrapper>
-        <Component {...pageProps} />
+        {router.isReady && <Component {...pageProps} />}
       </ToastWrapper>
     </Provider>
   );
 }
+
 export default appWithTranslation(TellaWeb);

--- a/pages/report/index.tsx
+++ b/pages/report/index.tsx
@@ -52,21 +52,16 @@ export const Report = () => {
   const [query, setQuery] = useState<ReportQuery>(defaultQuery);
   const itemQuery = useMemo(() => toItemQuery(query), [query]);
 
-  const { data: reports, refetch } = useListQuery(query);
+  const { data: reports } = useListQuery(query);
   const [batchDelete] = useBatchDeleteMutation();
 
   const onBatchDelete = async (reportsToDelete: IReport[]) => {
     const toDelete = reportsToDelete.map((td) => td.id);
-    const deleted = await batchDelete(toDelete).unwrap();
-    if (deleted) refetch();
+    batchDelete(toDelete).unwrap();
   };
 
-  useEffect(() => {
-    refetch()
-  }, [])
-
   return ready ? (
-    <ReportListPage      
+    <ReportListPage
       currentQuery={itemQuery}
       onQueryChange={(itemQuery) => setQuery(toReportQuery(itemQuery))}
       onDelete={onBatchDelete}

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -66,10 +66,6 @@ export const Report = () => {
     }
   }, [createUserResult.status]);
 
-  useEffect(() => {
-    refetch()
-  }, [])
-
   return ready ? (
     <UserListPage 
       currentQuery={itemQuery}


### PR DESCRIPTION
In the source code the middelwares of the APIs created with redux toolkits were missing.
In this pull request I do:

- Add the middelwares
- Manage the cache in the Reports API
- Avoid second renderings 
- Remove unnecessary refetches (because cache invalidation is being done behind the scenes)

Remains to be done: managing the file cache and the relationship of the file cache with the report cache.