### PR TITLE
change password modal and endpoint for users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tellaweb/webapp",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/packages/state/services/user.ts
+++ b/packages/state/services/user.ts
@@ -52,16 +52,18 @@ export const userApi = createApi({
     { 
       id: string, 
       username?: string,
+      password?: string,
       note?: string     
       role: string
     }>({
-      query: ({ id, username = null, note, role }) => ({
+      query: ({ id, username = null, password = null, note, role }) => ({
         url: `/${id}`,
         method: "POST",
         body: {
           note: note,
           username: username,
-          role: role
+          role: role,
+          password: password
         },
       }),
     }),
@@ -81,7 +83,7 @@ export const userApi = createApi({
       }),
     }),
 
-    updatePassword: builder.mutation<boolean, { current: string; new: string }>(
+    updatePasswordSelf: builder.mutation<boolean, { current: string; new: string }>(
       {
         query: (passwords) => ({
           url: `/change-password`,
@@ -115,10 +117,10 @@ export const userApi = createApi({
       },
     }),
 
-    getByUsername: builder.query<User, string>({
-      query: (username) => {
+    getById: builder.query<User, string>({
+      query: (id) => {
         return {
-          url: `/${username}`
+          url: `/${id}`
         }
       }
     }),
@@ -161,10 +163,10 @@ export const {
   useValidateEmailQuery,
   useUpdateUserMutation,
   useUpdateUserSelfMutation,
-  useUpdatePasswordMutation,
+  useUpdatePasswordSelfMutation,
   useConfirmPasswordMutation,
   useListQuery,
-  useLazyGetByUsernameQuery,
+  useGetByIdQuery,
   useDeleteMutation,
   useBatchDeleteUserMutation,
   useCreateUserMutation,

--- a/packages/ui/components/EditSelfPasswordModal/EditSelfPasswordModal.tsx
+++ b/packages/ui/components/EditSelfPasswordModal/EditSelfPasswordModal.tsx
@@ -3,10 +3,11 @@ import { ButtonPopup, Button, TextInput } from '../..'
 import { btnType } from '../Button/Button'
 import PasswordMeter from '../PasswordMeter/PasswordMeter'
 import zxcvbn from 'zxcvbn'
-
+import { FocusEvent } from 'react'
 type Props = {
   onSubmit: (currentPassword: string, newPassword: string) => void
 }
+
 
 export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Props>> = ({ onSubmit }) => {
   const [oldPassword, handleOldPassword] = useState<string>('')
@@ -18,6 +19,12 @@ export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Pr
   useEffect(() => {
     handlePasswordStrength(zxcvbn(newPassword).score)
   }, [newPassword])
+
+  const handleInput = (e: FocusEvent<HTMLInputElement>, isFocus: boolean) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      handleShowValidations(!isFocus)
+    }
+  }
 
   return (
     <ButtonPopup       
@@ -44,16 +51,8 @@ export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Pr
               type='password'
               value={oldPassword}
               onChange={(e) => { handleOldPassword(e.target.value) }}
-              onFocus={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(false)
-                }
-              }}
-              onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(true)
-                }
-              }}
+              onFocus={(e) => handleInput(e, true)}
+              onBlur={(e) => handleInput(e, false)}
             />
           </div>
           
@@ -64,16 +63,8 @@ export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Pr
               type='password'
               value={newPassword}
               onChange={(e) => { handleNewPassword(e.target.value) }}
-              onFocus={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(false)
-                }
-              }}
-              onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(true)
-                }
-              }}
+              onFocus={(e) => handleInput(e, true)}
+              onBlur={(e) => handleInput(e, false)}
             />
           </div>
 
@@ -90,16 +81,8 @@ export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Pr
               type='password'          
               value={confirmPassword}
               onChange={(e) => { handleConfirmPassword(e.target.value) }}
-              onFocus={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(false)
-                }
-              }}
-              onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  handleShowValidations(true)
-                }
-              }}
+              onFocus={(e) => handleInput(e, true)}
+              onBlur={(e) => handleInput(e, false)}
             /> 
           </div>
 

--- a/packages/ui/components/EditSelfPasswordModal/EditSelfPasswordModal.tsx
+++ b/packages/ui/components/EditSelfPasswordModal/EditSelfPasswordModal.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useState, useEffect } from 'react'
-import { ButtonPopup, Button, TextInput } from '../../'
+import { ButtonPopup, Button, TextInput } from '../..'
 import { btnType } from '../Button/Button'
 import PasswordMeter from '../PasswordMeter/PasswordMeter'
 import zxcvbn from 'zxcvbn'
@@ -8,7 +8,7 @@ type Props = {
   onSubmit: (currentPassword: string, newPassword: string) => void
 }
 
-export const EditPasswordModal: FunctionComponent<React.PropsWithChildren<Props>> = ({ onSubmit }) => {
+export const EditSelfPasswordModal: FunctionComponent<React.PropsWithChildren<Props>> = ({ onSubmit }) => {
   const [oldPassword, handleOldPassword] = useState<string>('')
   const [newPassword, handleNewPassword] = useState<string>('')
   const [confirmPassword, handleConfirmPassword] = useState<string>('')

--- a/packages/ui/modals/project/ManageUsersProjectModal/ManageUsersProjectModal.tsx
+++ b/packages/ui/modals/project/ManageUsersProjectModal/ManageUsersProjectModal.tsx
@@ -41,8 +41,6 @@ export const ManageUsersProjectModal: FunctionComponent<React.PropsWithChildren<
     handleParsedUserList(parsed)
   }, [users])
 
-  console.log("🚀 ~ file: ManageUsersProjectModal.tsx:31 ~ users:", users)
-
   return (
     <Modal 
       title='Add users to project'

--- a/packages/ui/modals/user/EditPasswordModal/EditPasswordModal.tsx
+++ b/packages/ui/modals/user/EditPasswordModal/EditPasswordModal.tsx
@@ -1,0 +1,109 @@
+import { FunctionComponent, useState, useEffect } from 'react'
+import { ButtonPopup, Button, TextInput } from '../../../'
+
+
+import zxcvbn from 'zxcvbn'
+import { btnType } from 'packages/ui/components/Button/Button'
+import PasswordMeter from 'packages/ui/components/PasswordMeter/PasswordMeter'
+
+type Props = {
+  onSubmit: (newPassword: string) => void
+}
+
+export const EditPasswordModal: FunctionComponent<React.PropsWithChildren<Props>> = ({ onSubmit }) => {
+  const [newPassword, handleNewPassword] = useState<string>('')
+  const [confirmPassword, handleConfirmPassword] = useState<string>('')
+  const [showValidations, handleShowValidations] = useState<boolean>(false)
+  const [passwordStrength, handlePasswordStrength] = useState<number>(0)
+
+  useEffect(() => {
+    handlePasswordStrength(zxcvbn(newPassword).score)
+  }, [newPassword])
+
+  return (
+    <ButtonPopup       
+      toggleButton={(toggle) => (
+        <Button
+          text="CHANGE PASSWORD"
+          onClick={toggle}
+          type={btnType.Secondary}
+        />
+      )}
+      render={(toggle) => (
+        <div className='p-4'>
+          <p className='py-2 font-sans text-gray-600 text-xxxl font-bold'>
+            Edit password
+          </p>
+          <p className='font-sans text-sm font-normal text-gray-500'>
+            Please enter your current password and new password.           
+          </p>      
+          
+          <div>
+            <TextInput
+              name='new-password'
+              placeholder='New password'
+              type='password'
+              value={newPassword}
+              onChange={(e) => { handleNewPassword(e.target.value) }}
+              onFocus={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget)) {
+                  handleShowValidations(false)
+                }
+              }}
+              onBlur={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget)) {
+                  handleShowValidations(true)
+                }
+              }}
+            />
+          </div>
+
+          {newPassword.length > 0 && (
+            <div>
+              <PasswordMeter score={passwordStrength} />
+            </div>
+          )}
+
+          <div className='py-4'>
+            <TextInput 
+              name='confirm-password'
+              placeholder='Confirm new password'
+              type='password'          
+              value={confirmPassword}
+              onChange={(e) => { handleConfirmPassword(e.target.value) }}
+              onFocus={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget)) {
+                  handleShowValidations(false)
+                }
+              }}
+              onBlur={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget)) {
+                  handleShowValidations(true)
+                }
+              }}
+            /> 
+          </div>
+
+          { showValidations && newPassword.length > 0 && confirmPassword.length > 0 && !(newPassword === confirmPassword) && (
+            <div className="w-full p-2 my-4  bg-red-100 text-center text-red-900 text-sm rounded-md border border-red-200">
+              Your new passwords do not match
+            </div>
+          )}
+
+          <div className='pb-4'>
+            <Button 
+              text='SAVE'
+              full={true}
+              disabled={!(newPassword.length > 0 && newPassword === confirmPassword)}
+              onClick={() => {
+                onSubmit(newPassword)
+                toggle()
+              }}
+            />
+          </div>
+          
+        </div>
+      )}
+    />
+  )
+}

--- a/packages/ui/pages/ProjectUsersPage/ProjectUsersPage.tsx
+++ b/packages/ui/pages/ProjectUsersPage/ProjectUsersPage.tsx
@@ -59,6 +59,7 @@ export const ProjectUsersPage: FunctionComponent<React.PropsWithChildren<Props>>
 }) => {
   const [currentUser, setCurrentUser] = useState<User | undefined>();
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  console.log("🚀 ~ selectedUsers:", selectedUsers)
 
   const openUser = () => {
     setCurrentUser(selectedUsers[0]);

--- a/packages/ui/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/ui/pages/SettingsPage/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useState } from "react";
 import { MainLayout } from "../../layouts/MainLayout";
 import { EditEmailModal } from "../../components/EditEmailModal/EditEmailModal";
-import { EditPasswordModal } from "../../components/EditPasswordModal/EditPasswordModal";
+import { EditSelfPasswordModal } from "../../components/EditSelfPasswordModal/EditSelfPasswordModal";
 import { TwoFactorAuthModal } from "packages/ui/components/TwoFactorAuthModal/TwoFactorAuthModal";
 import { ButtonMenu } from '../../components/ButtonMenu/ButtonMenu'
 import { ButtonOption } from '../../components/ButtonMenu/ButtonOption'
@@ -68,7 +68,7 @@ export const SettingsPage: FunctionComponent<React.PropsWithChildren<Props>> = (
               </p>
               <p>••••••••••</p>
             </div>
-            <EditPasswordModal onSubmit={onUpdatePassword} />
+            <EditSelfPasswordModal onSubmit={onUpdatePassword} />
           </div>
 
           <div className="flex justify-between items-center py-4 border-b">

--- a/packages/ui/pages/UserPage/UserPage.tsx
+++ b/packages/ui/pages/UserPage/UserPage.tsx
@@ -10,16 +10,16 @@ import {
 import { MainLayout } from "../../layouts/MainLayout"
 import { ROLES, User } from "packages/state/domain/user"
 import { EditEmailModal } from "../../components/EditEmailModal/EditEmailModal";
-import { EditPasswordModal } from "../../components/EditPasswordModal/EditPasswordModal";
 import { DeleteUserModal } from '../../components/DeleteUserModal/DeleteUserModal'
 import { EditUserNoteModal } from '../../components/EditUserNoteModal/EditUserNoteModal'
 import { useUserProfile } from "packages/state/features/user/userHooks";
 import { EditRoleModal } from '../../modals/user/EditRoleModal/EditRoleModal'
+import { EditPasswordModal } from "packages/ui/modals/user/EditPasswordModal/EditPasswordModal";
 
 type Props = {
   sidebar: React.ReactNode;
   onUpdateUsername: (username: string) => void;
-  onUpdatePassword: (currentPassword: string, newPassword: string) => void;
+  onUpdatePassword: (newPassword: string) => void;
   onUpdateNote: (note: string) => void;
   onUpdateRole: (role: string) => void;
   deleteUser: () => void

--- a/pages/resource/index.tsx
+++ b/pages/resource/index.tsx
@@ -5,10 +5,6 @@ import { Menu } from "../../components/Menu";
 import { useAuthRequired } from "packages/state/features/auth/authHooks";
 import { useUserProfile } from "packages/state/features/user/userHooks";
 import { useToast } from "components/ToastWrapper";
-import {
-  useUpdatePasswordMutation,
-  useUpdateUserMutation
-} from "packages/state/services/user";
 import { useDispatch } from "react-redux";
 import { setUser } from "packages/state/features/user/userSlice";
 import { ResourceListPage } from "packages/ui/pages/ResourceListPage/ResourceListPage";

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -6,8 +6,7 @@ import { useAuthRequired } from "packages/state/features/auth/authHooks";
 import { useUserProfile } from "packages/state/features/user/userHooks";
 import { useToast } from "components/ToastWrapper";
 import {
-  useUpdatePasswordMutation,
-  useUpdateUserMutation,
+  useUpdatePasswordSelfMutation,
   useUpdateUserSelfMutation
 } from "packages/state/services/user";
 import { useDispatch } from "react-redux";
@@ -20,7 +19,7 @@ const Settings = () => {
 
   const handleToast = useToast();
 
-  const [updatePassword, updatePasswordResult] = useUpdatePasswordMutation();
+  const [updatePassword, updatePasswordResult] = useUpdatePasswordSelfMutation();
   const [updateSelf, updateSelfResult] = useUpdateUserSelfMutation();
 
   const [otpActive, handleOtpActive] = useState<boolean | null>(null)
@@ -28,7 +27,6 @@ const Settings = () => {
   useEffect(() => {
     handleOtpActive(user.otp_active)
   }, [user])
-
 
   useEffect(() => {
     if (updatePasswordResult.isSuccess) {

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -5,9 +5,8 @@ import { Menu } from "../../components/Menu";
 import { useAuthRequired } from "packages/state/features/auth/authHooks";
 import { useToast } from "components/ToastWrapper";
 import {
-  useUpdatePasswordMutation,
   useUpdateUserMutation,
-  useLazyGetByUsernameQuery,
+  useGetByIdQuery,
   useDeleteMutation
 } from "packages/state/services/user";
 
@@ -15,38 +14,19 @@ const UserById: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
   
   const router = useRouter();
   const handleToast = useToast()
-   
-  const [currentUsername, handleCurrentUsername] = useState<string>()
-  const [loadUser, { data: currentUser }] = useLazyGetByUsernameQuery();
-  const [updatePassword, updatePasswordResult] = useUpdatePasswordMutation();
+     
   const [updateUser, updateUserResult] = useUpdateUserMutation();
   const [deleteUser, deleteUserResult] = useDeleteMutation()
 
-  const username = useMemo(() => {
-    if (router.query?.username && typeof router.query.username !== "string")
-      return router.query.username.toString();
-    return router.query.username as string;
-  }, [router.query?.username]);
-
-  useEffect(() => {
-    username && loadUser(username);
-    username && handleCurrentUsername(username)
-  }, [username, loadUser]);  
-
-  useEffect(() => {
-    if (updatePasswordResult.isSuccess) {
-      handleToast("Password updated!", "info");
-    }
-    if (updatePasswordResult.error && "status" in updatePasswordResult.error) {
-      handleToast(updatePasswordResult.error.data.message, "danger");
-    }
-  }, [updatePasswordResult.status]);
+  const { data: currentUser, refetch } = useGetByIdQuery(
+    "" + router.query.userId
+  )
 
   useEffect(() => {
     if (updateUserResult.isSuccess) {
       handleToast("User updated!", "info");
-      router.push(`./${currentUsername}`)
-      loadUser(currentUsername)
+      router.push(`./${currentUser.id}`)
+      refetch()
     }
     if (updateUserResult.error && "status" in updateUserResult.error) {
       handleToast(updateUserResult.error.data.message, "danger");
@@ -75,11 +55,15 @@ const UserById: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
           role: role
         });
       }}
-      onUpdatePassword={(current, newPassword) => {
-        updatePassword({ current, new: newPassword });
+      onUpdatePassword={(newPassword) => {
+        updateUser({ 
+          password: newPassword,
+          id: currentUser.id,
+          note: currentUser.note,
+          role: currentUser.role
+        });
       }}
       onUpdateUsername={(username, isAdmin = false) => {
-        handleCurrentUsername(username)
         updateUser({ 
           id: currentUser.id, 
           username: username,

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -94,7 +94,7 @@ export const Report = () => {
       sidebar={<Menu />}
       users={users?.results || []}
       onOpen={(user) => {
-        push(`./user/${user.username}`);
+        push(`./user/${user.id}`);
       }}
       onDelete={onBatchDeleteUsers}
       onCreateUser={createUser} 


### PR DESCRIPTION
https://app.asana.com/0/1199584685142713/1208907711922232

- add new modal for changing password without current password confirmation
- make user get by id instead of username to keep consistency with the rest of the codebase
- change endpoint on user crud edit 